### PR TITLE
Fix typo in troubleshooting section heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Private plugin uploads expire after 1 hour for security purposes. You'll need to
 
 ## Troubleshooting
 
-### Plugin Not Showing in Governing
+### Plugin Not Showing on the governing site
 
 - Verify governing site configuration  
 - Check network connectivity between sites  


### PR DESCRIPTION
## What
Fix typo in troubleshoot heading "Governing" to "Governing site"
