### PR TITLE
chore: make plugin wp.org release ready

### DIFF
--- a/.github/workflows/release_on_tag.yml
+++ b/.github/workflows/release_on_tag.yml
@@ -40,7 +40,6 @@ jobs:
           cp readme.txt /tmp/oneupdate/
           cp uninstall.php /tmp/oneupdate/
           cp -r vendor/ /tmp/oneupdate/
-          cp -r languages/ /tmp/oneupdate/
           
           # Create the zip file
           cd /tmp

--- a/.github/workflows/release_on_tag.yml
+++ b/.github/workflows/release_on_tag.yml
@@ -37,7 +37,7 @@ jobs:
           cp composer.json /tmp/oneupdate/
           cp -r inc/ /tmp/oneupdate/
           cp oneupdate.php /tmp/oneupdate/
-          cp README.md /tmp/oneupdate/
+          cp readme.txt /tmp/oneupdate/
           cp uninstall.php /tmp/oneupdate/
           cp -r vendor/ /tmp/oneupdate/
           cp -r languages/ /tmp/oneupdate/

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "rtcamp/oneupdate",
-	"version": "1.0.2",
+	"version": "1.0.0",
 	"description": "OneUpdate - Enterprise WordPress Plugin Manager Automate plugin updates across multiple WordPress sites with CI/CD integration. Creates pull requests for seamless development-to-production workflows.",
 	"type": "wordpress-plugin",
 	"autoload": {

--- a/oneupdate.php
+++ b/oneupdate.php
@@ -2,15 +2,15 @@
 /**
  * Plugin Name: OneUpdate
  * Plugin URI: https://github.com/rtCamp/OneUpdate/
- * Version: 1.0.2
+ * Version: 1.0.0
  * Description: OneUpdate - Enterprise WordPress Plugin Manager Automate plugin updates across multiple WordPress sites with CI/CD integration. Creates pull requests for seamless development-to-production workflows.
  * Author: Utsav Patel, rtCamp
  * Author URI: https://rtcamp.com
  * Text Domain: oneupdate
  * Domain Path: /languages
- * Requires at least: 6.5.0
- * Requires PHP: 7.4
- * Tested up to: 6.8.2
+ * Requires at least: 6.5
+ * Requires PHP: 8.0
+ * Tested up to: 6.8
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  *
@@ -87,9 +87,6 @@ if ( file_exists( ONEUPDATE_PLUGIN_LOADER_FEATURES_PATH . '/vendor/autoload.php'
  */
 function oneupdate_plugin_loader() {
 	\OneUpdate\Plugin::get_instance();
-
-	// load plugin text domain.
-	load_plugin_textdomain( 'oneupdate', false, ONEUPDATE_PLUGIN_LOADER_RELATIVE_PATH . '/languages/' );
 }
 
 add_action( 'plugins_loaded', 'oneupdate_plugin_loader' );

--- a/oneupdate.php
+++ b/oneupdate.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'ONEUPDATE_PLUGIN_LOADER_VERSION', '1.0.2' );
+define( 'ONEUPDATE_PLUGIN_LOADER_VERSION', '1.0.0' );
 define( 'ONEUPDATE_PLUGIN_LOADER_FEATURES_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'ONEUPDATE_PLUGIN_LOADER_RELATIVE_PATH', dirname( plugin_basename( __FILE__ ) ) );
 define( 'ONEUPDATE_PLUGIN_LOADER_FEATURES_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "oneupdate",
-	"version": "1.0.2",
+	"version": "1.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "oneupdate",
-	"version": "1.0.2",
+	"version": "1.0.0",
 	"description": "OneUpdate - Enterprise WordPress Plugin Manager Automate plugin updates across multiple WordPress sites with CI/CD integration. Creates pull requests for seamless development-to-production workflows.",
 	"private": true,
 	"author": "rtCamp",

--- a/readme.txt
+++ b/readme.txt
@@ -3,13 +3,13 @@ Contributors: Utsav Patel, rtCamp
 Donate link: https://rtcamp.com/
 Tags: plugin manager, CI/CD, automation, enterprise
 Requires at least: 6.5
-Tested up to: 6.8.2
-Stable tag: 1.0.1
-Requires PHP: 7.4
+Tested up to: 6.8
+Stable tag: 1.0.0
+Requires PHP: 8.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Centralized plugin management for multiple WordPress sites using CI/CD workflows. Automate plugin updates across development, staging, and production environments.
+Centralized plugin management for WordPress sites via CI/CD. Automate updates across development, staging, and production environments.
 
 == Description ==
 


### PR DESCRIPTION
- changer plugin version to 1.0.0
- update release workflow to only include necessary files
- removed `load_plugin_textdomain()` as per https://make.wordpress.org/core/2024/10/21/i18n-improvements-6-7/
- fix readme.txt issues.