### PR TITLE
Finish repo configurations (Step 3)

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -1,4 +1,4 @@
-# pre-commit:
-#   commands:
-#     lint-staged:
-#       run: npx --no-install lint-staged
+pre-commit:
+  commands:
+    lint-staged:
+      run: npx --no-install lint-staged

--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -11,7 +11,7 @@ export default {
 	'**/*.php': ( filenames ) => {
 		const cwd = process.cwd();
 		const relativeFilenames = filenames
-			.map( ( filename ) => `"${ filename.replace( cwd + '/', '' ) }"` )
+			.map( ( filename ) => `'${ filename.replace( cwd + '/', '' ) }'` )
 			.join( ' ' );
 
 		// Only fail if phpcbf itself failed (exit code 3).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,36 @@
 ## Important Files
-- @docs/DEVELOPMENT.md: Detailed development guidelines, tools, directory tree map, and best practices.
-- inc/: Contains the main plugin PHP code.
-- assets/src/: Contains the source files for the plugin's assets (JavaScript, CSS).
-- package.json: Contains our script commands.
+
+- @docs/DEVELOPMENT.md: detailed development guidelines and instructions, tools, directory tree map, and best practices.
+- inc/: contains the main plugin code
+- assets/src/: contains the source files for the plugin's assets (e.g., JavaScript, CSS).
+- package.json: contains our script commands.
 
 ## Important Notes
-Use `wp-env` for local development and testing. Key commands include:
-- `npm run wp-env {command}`: Manage the local environment.
-- `npm run wp-env:cli {command}`: Run commands inside the local environment's CLI container.
-- `npm run wp-env run {container} -- --env-cwd=wp-content/plugins/oneupdate {command}`: Run commands inside a specific container in the plugin directory.
-- `npm run wp-env start --xdebug-mode=coverage`: Start local environment with Xdebug enabled.
-- `npm run wp-env:cli -- composer install`: Install composer dependencies inside the CLI container.
+
+- Use `wp-env` (v11 parallel environments setup) for local development and testing:
+
+  ```cli
+  # Start the governing site (port 8888)
+  npm run wp-env start
+
+  # Start the child/brand site (port 8890)
+  npm run wp-env:child start
+
+  # Start the test environment (port 8889)
+  npm run wp-env:test start
+
+  # Run CLI/Composer commands in the governing site
+  npm run wp-env:cli -- composer install
+
+  # Run CLI commands in the child site
+  npm run wp-env:child run cli -- --env-cwd=wp-content/plugins/oneupdate {command}
+
+  # Run PHPUnit tests
+  npm run test:php
+  ```
+
+- Git Hooks & Pre-commit:
+  - Lefthook manages the git hooks. You can manually run the pre-commit hook on staged files with:
+    ```bash
+    npx --no-install lint-staged
+    ```

--- a/inc/Modules/Rest/Abstract_REST_Controller.php
+++ b/inc/Modules/Rest/Abstract_REST_Controller.php
@@ -77,12 +77,14 @@ abstract class Abstract_REST_Controller extends \WP_REST_Controller implements R
 		$request_origin = ! empty( $request_origin ) ? esc_url_raw( wp_unslash( $request_origin ) ) : '';
 		$parsed_origin  = wp_parse_url( $request_origin );
 		$request_url    = ! empty( $parsed_origin['scheme'] ) && ! empty( $parsed_origin['host'] ) ? sprintf(
-			'%s://%s',
+			'%s://%s%s',
 			$parsed_origin['scheme'],
-			$parsed_origin['host']
+			$parsed_origin['host'],
+			isset( $parsed_origin['port'] ) ? ':' . $parsed_origin['port'] : ''
 		) : '';
 
-		if ( empty( $request_url ) || $this->is_url_from_host( get_site_url(), $parsed_origin['host'] ) ) {
+		$origin_port = $parsed_origin['port'] ?? 80;
+		if ( empty( $request_url ) || $this->is_url_from_host( get_site_url(), $parsed_origin['host'], $origin_port ) ) {
 			return current_user_can( 'manage_options' );
 		}
 
@@ -106,7 +108,7 @@ abstract class Abstract_REST_Controller extends \WP_REST_Controller implements R
 		// If it's not a healthcheck, compare the origins.
 		$governing_site_url = Settings::get_parent_site_url();
 		if ( '/' . $this->namespace . '/health-check' !== $request->get_route() ) {
-			return ! empty( $governing_site_url ) ? $this->is_url_from_host( $governing_site_url, $parsed_origin['host'] ) : false;
+			return ! empty( $governing_site_url ) ? $this->is_url_from_host( $governing_site_url, $parsed_origin['host'], $origin_port ) : false;
 		}
 
 		// For health-checks, if no governing site is set, we set it now.
@@ -117,15 +119,27 @@ abstract class Abstract_REST_Controller extends \WP_REST_Controller implements R
 	/**
 	 * Check if two URLs belong to the same host.
 	 *
-	 * @param string $url  The URL to check.
-	 * @param string $host The host to compare against.
+	 * @param string   $url  The URL to check.
+	 * @param string   $host The host to compare against.
+	 * @param int|null $port Optional. The port to compare against.
 	 *
-	 * @return bool True if both URLs belong to the same domain, false otherwise.
+	 * @return bool True if both URLs belong to the same host (and port if specified), false otherwise.
 	 */
-	private function is_url_from_host( string $url, string $host ): bool {
+	protected function is_url_from_host( string $url, string $host, ?int $port = null ): bool {
 		$parsed_url = wp_parse_url( $url );
 
-		return isset( $parsed_url['host'] ) && $parsed_url['host'] === $host;
+		// Compare both host and port to properly handle localhost with different ports.
+		if ( ! isset( $parsed_url['host'] ) || $parsed_url['host'] !== $host ) {
+			return false;
+		}
+
+		// If a port was provided, also compare ports.
+		if ( null !== $port ) {
+			$url_port = $parsed_url['port'] ?? 80;
+			return $url_port === $port;
+		}
+
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
## What

This PR updates project documentation, improves developer tooling, and introduces a bug fix for origin and port comparison in REST API permission checks.

## Why

The previous REST API permission checks did not adequately handle environments using different ports on the same host (e.g., `localhost:8888` vs. `localhost:8890`), which caused issues in local development environments. Additionally, the developer workflow needed clearer instructions and automated pre-commit checks to improve code quality and onboarding.

### Related Issue(s):
Covers Step 3 : https://github.com/rtCamp/OnePress/issues/78
Step 1 : https://github.com/rtCamp/oneupdate/pull/149


## How

* **REST API Permission Validation:**
* Updated `is_url_from_host` in `Abstract_REST_Controller.php` to accept an optional port parameter, ensuring both host and port are compared.
* Changed visibility of `is_url_from_host` from private to protected.
* Updated `check_api_permissions` to pass the port when calling `is_url_from_host` to improve security and correctness.


* **Developer Documentation:**
* Updated `AGENTS.md` with instructions for local development using `wp-env`, including parallel environment setup, explicit CLI commands, and documentation for running pre-commit hooks with Lefthook and `lint-staged`.


* **Developer Tooling:**
* Enabled the pre-commit hook for `lint-staged` in `.lefthook.yml`.
* Updated `.lintstagedrc.mjs` to wrap filenames in single quotes instead of double quotes for PHP file linting commands to improve compatibility.



## Testing Instructions

1. Set up the local development environment using the updated `wp-env` instructions in `AGENTS.md`.
2. Perform a REST API request between environments running on the same host but different ports (e.g., `localhost:8888` and `localhost:8890`) to verify that permission checks evaluate correctly.
3. Modify a PHP file and attempt to commit the change to verify that the `lint-staged` pre-commit hook triggers automatically and lints the file.

## Screenshots

N/A

## Additional Info

N/A

## Checklist

* [x] I have read the [Contribution Guidelines(https://github.com/rtCamp/OneUpdate/blob/main/docs/CONTRIBUTING.md).
* [x] I have read the [Development Guidelines(https://github.com/rtCamp/OneUpdate/blob/main/docs/DEVELOPMENT.md).
* [x] My code is tested to the best of my abilities.
* [x] My code passes all lints (ESLint etc.).
* [x] My code has detailed inline documentation.
* [x] I have updated the project documentation as needed.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22meta%22%3A%7B%22title%22%3A%22OneUpdate%20Demo%22%2C%22description%22%3A%22OneUpdate%20-%20Enterprise%20WordPress%20Plugin%20Manager.%20Automate%20plugin%20updates%20across%20multiple%20WordPress%20sites%20with%20CI%2FCD%20integration.%20Creates%20pull%20requests%20for%20seamless%20development-to-production%20workflows.%22%2C%22author%22%3A%22rtCamp%22%2C%22categories%22%3A%5B%22plugin%22%2C%22updates%22%2C%22multisite%22%2C%22aws%22%2C%22enterprise%22%2C%22cicd%22%5D%7D%2C%22landingPage%22%3A%22%2Fwp-admin%2Fplugins.php%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.1%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FrtCamp%2Foneupdate%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-152-431590149f2cbc77990a1932faf88267d5bbf85d.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->